### PR TITLE
Fix Docker Docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN python scripts/_locale.py --compile
 # compile docs
 RUN \
   cd docs && \
-  sphinx-build -b html source build
+  sphinx-build -M html source build
 
 # setup user
 RUN \


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
- Build docs using Make equivalent.
  - Link to docs does not currently work on docker image.
 
This PR fixes that by building the docs using the `-M` flag instead of the `-b` flag.

## Type of Change
<!--- Please delete options that are not relevant. --->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring/documentation-blocks for new or existing methods/components
